### PR TITLE
Galloper & 'Active Directory group' integration issue

### DIFF
--- a/galloper/api/project.py
+++ b/galloper/api/project.py
@@ -70,8 +70,8 @@ class ProjectAPI(Resource):
 
     def __get_project_count(self, _filter):
         if _filter is not None:
-            return Project.query.order_by(Project.id.desc()).count()
-        return Project.query.filter(_filter).order_by(Project.id.desc()).count()
+            return Project.query.filter(_filter).order_by(Project.id.desc()).count()
+        return Project.query.order_by(Project.id.desc()).count()
 
     def get(self, project_id: Optional[int] = None) -> Union[Tuple[dict, int], Tuple[list, int]]:
         args = self._parser_get.parse_args()

--- a/galloper/api/project.py
+++ b/galloper/api/project.py
@@ -68,6 +68,11 @@ class ProjectAPI(Resource):
         self._parser_get = build_req_parser(rules=self.get_rules)
         self._parser_post = build_req_parser(rules=self.post_rules)
 
+    def __get_project_count(self, _filter):
+        if _filter is not None:
+            return Project.query.order_by(Project.id.desc()).count()
+        return Project.query.filter(_filter).order_by(Project.id.desc()).count()
+
     def get(self, project_id: Optional[int] = None) -> Union[Tuple[dict, int], Tuple[list, int]]:
         args = self._parser_get.parse_args()
         offset_ = args["offset"]
@@ -90,7 +95,7 @@ class ProjectAPI(Resource):
                 projects = Project.query.filter(_filter).limit(limit_).offset(offset_).all()
             else:
                 projects = Project.query.limit(limit_).offset(offset_).all()
-        total = Project.query.order_by(Project.id.desc()).count()
+        total = self.__get_project_count(_filter)
         project_list = [project.to_json(exclude_fields=Project.API_EXCLUDE_FIELDS) for project in projects]
         return {"total": total, "rows": project_list}, 200
 

--- a/galloper/utils/auth.py
+++ b/galloper/utils/auth.py
@@ -122,7 +122,8 @@ def only_users_projects():
             group = int(group)
         except:
             group = group.replace("superadmin", "all")
-        project.append(group)
+        if group == "all" or isinstance(group, int):
+            project.append(group)
     return project
 
 


### PR DESCRIPTION
In production we faced with next situation -> Carrier KeyCloak integrated with customer's Active Directory, and users in AD has different internal 'groups' assigned to them. Almost all of them are not 'numeric' or 'superadmin'.
As the result, we are trying to pass into 'Int' filter 'non-int' values
SQL representation is:

'SELECT * FROM projects WHERE id IN (1, 'testGroupName')

At this point SQL driver will raise an exception and on the UI we will see '500' status code.

Fixes carrier-io/galloper#153