### PR TITLE
Do not expose on UI 'git user password' since it is sensitive info

### DIFF
--- a/galloper/api/planner.py
+++ b/galloper/api/planner.py
@@ -146,7 +146,8 @@ class TestApiBackend(Resource):
     _get_rules = (
         dict(name="raw", type=int, default=0, location="args"),
         dict(name="type", type=str, default='cc', location="args"),
-        dict(name="exec", type=str2bool, default=False, location="args")
+        dict(name="exec", type=str2bool, default=False, location="args"),
+        dict(name="source", type=str, default='legacy', location="args")
     )
 
     _put_rules = (
@@ -183,6 +184,8 @@ class TestApiBackend(Resource):
         else:
             _filter = and_(PerformanceTests.project_id == project.id, PerformanceTests.test_uid == test_id)
         test = PerformanceTests.query.filter(_filter).first()
+        if type(test.git) is dict and test.git['repo_pass'] is not None and len(test.git['repo_pass']) and args["source"] == "galloper":
+            test.git['repo_pass'] = "********"
         if args.raw:
             return test.to_json(["influx.port", "influx.host", "galloper_url",
                                  "influx.db", "comparison_db", "telegraf_db",

--- a/galloper/templates/planner/backend.html
+++ b/galloper/templates/planner/backend.html
@@ -136,7 +136,7 @@
                                                 </div>
                                                 <div class="col">
                                                   <label class="form-control-label" for="repo_pass">Git Password</label>
-                                                  <input type="password" id="repo_pass" class="form-control form-control-alternative" placeholder="(optional, for HTTPS URLs)">
+                                                  <input type="text" id="repo_pass" class="form-control form-control-alternative" placeholder="(optional, for HTTPS URLs)">
                                                 </div>
                                             </div>
                                             <div class="row">

--- a/galloper/templates/planner/backend.html
+++ b/galloper/templates/planner/backend.html
@@ -136,7 +136,7 @@
                                                 </div>
                                                 <div class="col">
                                                   <label class="form-control-label" for="repo_pass">Git Password</label>
-                                                  <input type="text" id="repo_pass" class="form-control form-control-alternative" placeholder="(optional, for HTTPS URLs)">
+                                                  <input type="password" id="repo_pass" class="form-control form-control-alternative" placeholder="(optional, for HTTPS URLs)">
                                                 </div>
                                             </div>
                                             <div class="row">
@@ -290,7 +290,7 @@
         if (test_id !== null) {
             var project_id = $("#selected-project-id").text();
             $.get(
-                `/api/v1/tests/${project_id}/backend/${test_id}`, { raw: 1 }, function( data ) {
+                `/api/v1/tests/${project_id}/backend/${test_id}`, { raw: 1, source: "galloper" }, function( data ) {
                     $('#submit').attr("onclick", "updateTest()");
                     $('#submit').text("Edit");
                     $('#testname').val(data.name);

--- a/galloper/templates/planner/tests.html
+++ b/galloper/templates/planner/tests.html
@@ -170,7 +170,7 @@
 
         var type = page_params.get("type")
         $.ajax({
-            url: `/api/v1/tests/${project_id}/${type}/${test_id}?raw=1`,
+            url: `/api/v1/tests/${project_id}/${type}/${test_id}?raw=1&source=galloper`,
             type: 'GET',
             success: function (result) {
                 console.log(result)


### PR DESCRIPTION
In case if endpoint requestor is galloper UI -> replace git password with '********'
Also, use HTML5 'password' text fields

Fixes carrier-io/galloper#155